### PR TITLE
WIP setup.py for pip mangement

### DIFF
--- a/ldc/__main__.py
+++ b/ldc/__main__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main():
+    os.system('ldc.sh ' + ' '.join(sys.argv[1:]))
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,12 @@ if __name__ == '__main__':
         version='0.0.1',
         author='Kitware',
         scripts=['ldc.sh'],
-        packages=[],
+
+        entry_points={
+            'console_scripts': [
+                # TODO: this is a better way of invoking executables
+                'ldc=ldc.__main__:main',
+            ],
+        },
+        packages=['ldc'],
     )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+
+if __name__ == '__main__':
+    setup(
+        name='ldc',
+        version='0.0.1',
+        author='Kitware',
+        scripts=['ldc.sh'],
+        packages=[],
+    )


### PR DESCRIPTION
This is a WIP, but has a working poc baseline.

I saw the viame instructions for how to install this, and I think we could do better.

At first I assumed this was a Python package, so I tried to pip install it. Then realized it was a shell script.

Either way, pip installing this would be a nice and easy way to mange the distribution, even though this isn't really Python (not sure what the pypi people think about that). It would be much easier for those already familiar with working in a python venv.

FWIW, the current install instructions could currently be rewritten as:

```
python -m pip install git+https://github.com/Erotemic/ldc.git@pip_management
type ldc.sh
```

It doesn't seem to remove ldc.sh from your venv bin when you pip uninstall it though. 